### PR TITLE
Feature/1234 correct page content

### DIFF
--- a/changes/1234.feature
+++ b/changes/1234.feature
@@ -1,0 +1,1 @@
+fix toolbar page content

--- a/cms_helper.py
+++ b/cms_helper.py
@@ -19,6 +19,7 @@ HELPER_SETTINGS = dict(
         "taggit",
         "taggit_autosuggest",
         "meta",
+        "djangocms_versioning",
         # "djangocms_page_tags",
         "tests.test_utils",
     ],

--- a/djangocms_page_meta/cms_toolbars.py
+++ b/djangocms_page_meta/cms_toolbars.py
@@ -11,7 +11,6 @@ from django.utils.translation import gettext_lazy as _
 
 from .models import DefaultMetaImage, PageMeta, TitleMeta
 
-
 PAGE_META_MENU_TITLE = _("Meta-information")
 PAGE_META_ITEM_TITLE = _("Common")
 PAGE_META_DEFAULT_META_IMAGE_TITLE = _("Default meta image")
@@ -75,8 +74,7 @@ class PageToolbarMeta(CMSToolbar):
             site_id = self.page.node.site_id
 
             contents = PageContent.admin_manager.filter(
-                page=self.page,
-                language__in=get_language_list(site_id)
+                page=self.page, language__in=get_language_list(site_id)
             ).current_content()
 
             # TODO: rename to content extensions

--- a/djangocms_page_meta/cms_toolbars.py
+++ b/djangocms_page_meta/cms_toolbars.py
@@ -1,18 +1,15 @@
 from cms.cms_toolbars import PAGE_MENU_SECOND_BREAK
+from cms.models import PageContent
 from cms.toolbar.items import Break
 from cms.toolbar_base import CMSToolbar
 from cms.toolbar_pool import toolbar_pool
+from cms.utils.conf import get_cms_setting
 from cms.utils.i18n import get_language_list, get_language_object
 from cms.utils.permissions import has_page_permission
 from django.urls import NoReverseMatch, reverse
 from django.utils.translation import gettext_lazy as _
 
 from .models import DefaultMetaImage, PageMeta, TitleMeta
-
-try:
-    from cms.utils import get_cms_setting
-except ImportError:
-    from cms.utils.conf import get_cms_setting
 
 
 PAGE_META_MENU_TITLE = _("Meta-information")
@@ -23,8 +20,6 @@ PAGE_META_DEFAULT_META_IMAGE_TITLE = _("Default meta image")
 @toolbar_pool.register
 class PageToolbarMeta(CMSToolbar):
     def populate(self):
-        # always use draft if we have a page
-        # self.page = get_page_draft(self.request.current_page)
         self.page = self.request.current_page
         if not self.page:
             # Nothing to do
@@ -41,10 +36,9 @@ class PageToolbarMeta(CMSToolbar):
         else:
             has_global_current_page_change_permission = False
             # check if user has page edit permission
-        permission = self.request.current_page.has_change_permission(self.request.user)
-        can_change = self.request.current_page and permission
+        permission = self.page.has_change_permission(self.request.user)
+        can_change = self.page and permission
         if has_global_current_page_change_permission or can_change:
-            not_edit_mode = not self.toolbar.edit_mode_active
 
             current_page_menu = self.toolbar.get_or_create_menu("page")
             super_item = current_page_menu.find_first(Break, identifier=PAGE_MENU_SECOND_BREAK)
@@ -76,30 +70,35 @@ class PageToolbarMeta(CMSToolbar):
                 # not in urls
                 pass
             else:
-                meta_menu.add_modal_item(PAGE_META_ITEM_TITLE, url=url, disabled=not_edit_mode, position=position)
-            # Title tags
+                meta_menu.add_modal_item(PAGE_META_ITEM_TITLE, url=url, position=position)
+            # Content tags
             site_id = self.page.node.site_id
-            titles = self.page.pagecontent_set.filter(language__in=get_language_list(site_id))
 
+            contents = PageContent.admin_manager.filter(
+                page=self.page,
+                language__in=get_language_list(site_id)
+            ).current_content()
+
+            # TODO: rename to content extensions
             title_extensions = {
                 t.extended_object_id: t
-                for t in TitleMeta.objects.filter(extended_object_id__in=[title.id for title in titles])
+                for t in TitleMeta.objects.filter(extended_object_id__in=[content.id for content in contents])
             }
 
-            for title in titles:
+            for content in contents:
                 try:
-                    if title.pk in title_extensions:
+                    if content.pk in title_extensions:
                         url = reverse(
-                            "admin:djangocms_page_meta_titlemeta_change", args=(title_extensions[title.pk].pk,)
+                            "admin:djangocms_page_meta_titlemeta_change", args=(title_extensions[content.pk].pk,)
                         )
                     else:
                         url = "{}?extended_object={}".format(
-                            reverse("admin:djangocms_page_meta_titlemeta_add"), title.pk
+                            reverse("admin:djangocms_page_meta_titlemeta_add"), content.pk
                         )
                 except NoReverseMatch:
                     # not in urls
                     pass
                 else:
                     position += 1
-                    language = get_language_object(title.language)
-                    meta_menu.add_modal_item(language["name"], url=url, disabled=not_edit_mode, position=position)
+                    language = get_language_object(content.language)
+                    meta_menu.add_modal_item(language["name"], url=url, position=position)

--- a/djangocms_page_meta/models.py
+++ b/djangocms_page_meta/models.py
@@ -24,6 +24,8 @@ try:
 except ImportError:
     registry = None
 
+from djangocms_versioning.constants import INDICATOR_DESCRIPTIONS
+
 
 class PageMeta(PageExtension):
     image = FilerFileField(
@@ -127,8 +129,12 @@ class TitleMeta(PageContentExtension):
         verbose_name = _("Page meta info (language-dependent)")
         verbose_name_plural = _("Page meta info (language-dependent)")
 
+    def get_version_status(self):
+        state = self.extended_object.versions.first().state
+        return INDICATOR_DESCRIPTIONS[state]
+
     def __str__(self):
-        return _("Title Meta for {0}").format(self.extended_object)
+        return _("Page Content Meta for {0}").format(self.extended_object) + f": {self.get_version_status()}"
 
     @property
     def locale(self):

--- a/djangocms_page_meta/utils.py
+++ b/djangocms_page_meta/utils.py
@@ -1,3 +1,4 @@
+from cms.models import PageContent
 from django.template.loader import render_to_string
 from django.utils.safestring import mark_safe
 from django.utils.translation import get_language_from_request
@@ -39,7 +40,7 @@ def get_page_meta(page, language):
     meta = cache.get(meta_key)
     if not meta:
         meta = Meta()
-        title = page.get_content_obj(language)
+        title = PageContent.admin_manager.filter(page=page, language=language).current_content().get()
         default_meta_image = DefaultMetaImage.objects.first().image
         meta.extra_custom_props = []
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -33,6 +33,7 @@ install_requires =
 	django-cms~=4.1
 	django-meta>=2.4.0
 	django-filer>=3.0
+    djangocms-versioning>=2
 setup_requires =
 	setuptools
 packages = djangocms_page_meta

--- a/tests/base.py
+++ b/tests/base.py
@@ -3,6 +3,7 @@ from copy import deepcopy
 
 from app_helper.base_test import CreateTestDataMixin
 from cms.api import create_page, create_page_content
+from cms.models import PageContent
 from cms.test_utils.testcases import CMSTestCase
 from django.contrib.auth.models import Permission
 from django.core.cache import cache
@@ -90,12 +91,14 @@ class BaseTest(CMSTestCase):
 
             main_data = deepcopy(page_data[self.language])
             main_data["language"] = self.language
+            main_data["created_by"] = self.superuser
             page = create_page(**main_data)
 
             for lang in self.languages[1:]:
                 context_data = deepcopy(page_data[lang])
                 context_data["language"] = lang
                 context_data["page"] = page
+                context_data["created_by"] = self.superuser
                 create_page_content(**context_data)
 
             if not home_set:
@@ -118,3 +121,8 @@ class BaseTest(CMSTestCase):
     def create_filer_image_object(self):
         self.filer_image = self.create_filer_image(self.staff_user, self.image_name)
         return self.filer_image
+
+    def publish_page(self, page, language):
+        content = PageContent.admin_manager.get(page=page, language=language)
+        version = content.versions.first()
+        version.publish(self.superuser)

--- a/tests/test_general.py
+++ b/tests/test_general.py
@@ -1,8 +1,10 @@
+from cms.models import PageContent
 from django.conf import settings
 from django.core.cache import cache
 from django.template.base import Parser
 from django.test import override_settings
 from django.utils.functional import SimpleLazyObject
+from djangocms_versioning.constants import INDICATOR_DESCRIPTIONS
 
 from djangocms_page_meta import models
 from djangocms_page_meta.forms import PageMetaAdminForm, TitleMetaAdminForm
@@ -182,7 +184,8 @@ class PageMetaUtilsTest(BaseTest):
         page1 = self.create_pages()[0]
         page_meta = models.PageMeta.objects.create(extended_object=page1)
         page_meta.save()
-        title_meta = models.TitleMeta.objects.create(extended_object=page1.get_content_obj("en"))
+        content = PageContent.admin_manager.get(page=page1, language="en")
+        title_meta = models.TitleMeta.objects.create(extended_object=content)
         title_meta.save()
 
         models.GenericMetaAttribute.objects.create(page=page_meta, attribute="custom", name="attr", value="foo")
@@ -196,29 +199,32 @@ class PageMetaUtilsTest(BaseTest):
         meta = get_page_meta(page1, "it")
         self.assertEqual(meta.extra_custom_props, [("custom", "attr", "foo")])
 
-    # def test_publish_extra(self):
-    #     """
-    #     Test that modified GenericMetaAttribute are not copied multiple times on page publish
-    #     See issue #78
-    #     """
-    #     page1 = self.create_pages()[0]
-    #     page_meta = models.PageMeta.objects.create(extended_object=page1)
-    #     title_meta = models.TitleMeta.objects.create(extended_object=page1.get_content_obj("en"))
-    #     models.GenericMetaAttribute.objects.create(page=page_meta, attribute="custom", name="attr", value="foo")
-    #     models.GenericMetaAttribute.objects.create(title=title_meta, attribute="custom", name="attr", value="bar")
-    #
-    #     page1.publish("en")
-    #     page_meta.extra.first().attribute = "new"
-    #     page_meta.extra.first().save()
-    #     title_meta.extra.first().attribute = "new"
-    #     title_meta.extra.first().save()
-    #
-    #     page1.publish("en")
-    #     public = page1.get_public_object()
-    #     page_meta = models.PageMeta.objects.get(extended_object=public)
-    #     title_meta = models.TitleMeta.objects.get(extended_object=public.get_content_obj("en"))
-    #     self.assertEqual(page_meta.extra.count(), 1)
-    #     self.assertEqual(title_meta.extra.count(), 1)
+    def test_publish_extra(self):
+        """
+        Test that modified GenericMetaAttribute are not copied multiple times on page publish
+        See issue #78
+        """
+        page1 = self.create_pages()[0]
+        page_meta = models.PageMeta.objects.create(extended_object=page1)
+        content = PageContent.admin_manager.get(page=page1, language="en")
+        title_meta = models.TitleMeta.objects.create(extended_object=content)
+        models.GenericMetaAttribute.objects.create(page=page_meta, attribute="custom", name="attr", value="foo")
+        models.GenericMetaAttribute.objects.create(title=title_meta, attribute="custom", name="attr", value="bar")
+
+        version = content.versions.first()
+        version.publish(self.superuser)
+        page_meta.extra.first().attribute = "new"
+        page_meta.extra.first().save()
+        title_meta.extra.first().attribute = "new"
+        title_meta.extra.first().save()
+
+        new_version = version.copy(self.superuser)
+        new_version.publish(self.superuser)
+        public = page1  # page no longer versioned
+        page_meta = models.PageMeta.objects.get(extended_object=public)
+        title_meta = models.TitleMeta.objects.get(extended_object=public.get_content_obj("en"))
+        self.assertEqual(page_meta.extra.count(), 1)
+        self.assertEqual(title_meta.extra.count(), 1)
 
     def test_str_methods(self):
         """
@@ -226,7 +232,8 @@ class PageMetaUtilsTest(BaseTest):
         """
         page1 = self.create_pages()[0]
         page_meta = models.PageMeta.objects.create(extended_object=page1)
-        title_meta = models.TitleMeta.objects.create(extended_object=page1.get_content_obj("en"))
+        content = PageContent.admin_manager.get(page=page1, language="en")
+        title_meta = models.TitleMeta.objects.create(extended_object=content)
         default_meta_image = models.DefaultMetaImage.objects.first()
         page_attr = models.GenericMetaAttribute.objects.create(
             page=page_meta, attribute="custom", name="attr", value="foo"
@@ -236,7 +243,7 @@ class PageMetaUtilsTest(BaseTest):
         )
 
         self.assertEqual(str(page_meta), f"Page Meta for {page1}")
-        self.assertEqual(str(title_meta), f"Title Meta for {page1.get_content_obj('en')}")
+        self.assertEqual(str(title_meta), f"Page Content Meta for {content}: {INDICATOR_DESCRIPTIONS['draft']}")
         self.assertEqual(str(default_meta_image), f"{default_meta_image.pk}")
         self.assertEqual(str(page_attr), f"Attribute {page_attr.name} for {page_meta}")
         self.assertEqual(str(title_attr), f"Attribute {title_attr.name} for {title_meta}")
@@ -258,7 +265,8 @@ class PageMetaUtilsTest(BaseTest):
         """
         page1 = self.create_pages()[0]
         page_meta = models.PageMeta.objects.create(extended_object=page1)
-        title_meta = models.TitleMeta.objects.create(extended_object=page1.get_content_obj("en"))
+        content = PageContent.admin_manager.get(page=page1, language="en")
+        title_meta = models.TitleMeta.objects.create(extended_object=content)
 
         # cache objects
         for language in page1.get_languages():
@@ -299,7 +307,8 @@ class PageMetaUtilsTest(BaseTest):
         """
         page1 = self.create_pages()[0]
         page_meta = models.PageMeta.objects.create(extended_object=page1)
-        title_meta = models.TitleMeta.objects.create(extended_object=page1.get_content_obj("en"))
+        content = PageContent.admin_manager.get(page=page1, language="en")
+        title_meta = models.TitleMeta.objects.create(extended_object=content)
 
         # cache objects - cache keys must be pre calculated as the page will not exist anymore when running the
         # asserts

--- a/tests/test_templatetags.py
+++ b/tests/test_templatetags.py
@@ -1,3 +1,5 @@
+from cms.models import PageContent
+
 from djangocms_page_meta.models import GenericMetaAttribute, PageMeta, TitleMeta
 
 from .base import BaseTest
@@ -17,8 +19,8 @@ class TemplateMetaTest(BaseTest):
         GenericMetaAttribute.objects.create(page=page_ext, attribute="custom", name="attr", value="foo")
         # page1.publication_end_date = page1.publication_date + timedelta(days=1)
         page1.save()
-        # page1.publish("it")
-        # page1.publish("en")
+        self.publish_page(page1, "it")
+        self.publish_page(page1, "en")
 
         response = self.client.get(page1.get_absolute_url("en"))
         self.assertContains(response, '<meta name="twitter:domain" content="example.com">')
@@ -39,7 +41,7 @@ class TemplateMetaTest(BaseTest):
         page_ext = PageMeta.objects.create(extended_object=page1)
         page_ext.save()
         page1.save()
-        # page1.publish("en")
+        self.publish_page(page1, "en")
         response = self.client.get(page1.get_absolute_url("en"))
         self.assertNotContains(response, '<meta name="robots"')
 
@@ -53,7 +55,7 @@ class TemplateMetaTest(BaseTest):
             setattr(page_ext, key, val)
         page_ext.save()
         page1.save()
-        # page1.publish("en")
+        self.publish_page(page1, "en")
         response = self.client.get(page1.get_absolute_url("en"))
         self.assertContains(response, '<meta name="robots" content="noindex">')
 
@@ -67,7 +69,7 @@ class TemplateMetaTest(BaseTest):
             setattr(page_ext, key, val)
         page_ext.save()
         page1.save()
-        # page1.publish("en")
+        self.publish_page(page1, "en")
         response = self.client.get(page1.get_absolute_url("en"))
         self.assertContains(response, '<meta name="robots" content="none, noimageindex, noarchive">')
 
@@ -76,20 +78,20 @@ class TemplateMetaTest(BaseTest):
         Test title-level templatetags
         """
         page1 = self.create_pages()[0]
-        title_en = page1.get_content_obj(language="en", fallback=False)
-        title_it = page1.get_content_obj(language="it", fallback=False)
-        title_ext = TitleMeta.objects.create(extended_object=title_en)
+        content_en = PageContent.admin_manager.get(page=page1, language="en")
+        content_it = PageContent.admin_manager.get(page=page1, language="it")
+        title_ext = TitleMeta.objects.create(extended_object=content_en)
         for key, val in self.title_data.items():
             setattr(title_ext, key, val)
         title_ext.save()
         GenericMetaAttribute.objects.create(title=title_ext, attribute="custom", name="attr", value="foo-en")
-        title_ext = TitleMeta.objects.create(extended_object=title_it)
+        title_ext = TitleMeta.objects.create(extended_object=content_it)
         for key, val in self.title_data_it.items():
             setattr(title_ext, key, val)
         title_ext.save()
         GenericMetaAttribute.objects.create(title=title_ext, attribute="custom", name="attr", value="foo-it")
-        # page1.publish("it")
-        # page1.publish("en")
+        self.publish_page(page1, "it")
+        self.publish_page(page1, "en")
 
         # Italian language
         response = self.client.get(page1.get_absolute_url("it"))
@@ -119,18 +121,18 @@ class TemplateMetaTest(BaseTest):
         Test title-level templatetags
         """
         page1, page2 = self.create_pages()
-        content_en = page1.get_content_obj(language="en", fallback=False)
+        content_en = PageContent.admin_manager.get(page=page1, language="en")
         content_en.meta_description = self.title_data["description"]
         content_en.save()
-        content_it = page1.get_content_obj(language="it", fallback=False)
+        content_it = PageContent.admin_manager.get(page=page1, language="it")
         content_it.meta_description = self.title_data_it["description"]
         content_it.save()
         content_ext_en = TitleMeta.objects.create(extended_object=content_en)
         content_ext_en.save()
         content_ext_it = TitleMeta.objects.create(extended_object=content_it)
         content_ext_it.save()
-        # page1.publish("it")
-        # page1.publish("en")
+        self.publish_page(page1, "it")
+        self.publish_page(page1, "en")
 
         # page1 = page1.get_draft_object()
         content_en = page1.get_content_obj(language="en", fallback=False)
@@ -179,10 +181,10 @@ class TemplateMetaTest(BaseTest):
         self.assertContains(response, '<meta name="twitter:description" content="twitter custom description">')
         self.assertContains(response, '<meta property="og:description" content="og custom description">')
 
-        title2_en = page2.get_content_obj(language="en", fallback=False)
-        title2_en.meta_description = self.title_data["description"]
-        title2_en.save()
-        # page2.publish("en")
+        content2_en = PageContent.admin_manager.get(page=page2, language="en")
+        content2_en.meta_description = self.title_data["description"]
+        content2_en.save()
+        self.publish_page(page2, "en")
         # English language
         # A page with no title meta, and yet the meta description is there
         response = self.client.get(page2.get_absolute_url("en"))

--- a/tests/test_toolbar.py
+++ b/tests/test_toolbar.py
@@ -1,3 +1,4 @@
+from cms.models import PageContent
 from cms.toolbar.items import Menu, ModalItem, SubMenu
 from cms.utils.i18n import get_language_object
 from django.test.utils import override_settings
@@ -148,7 +149,8 @@ class ToolbarTest(BaseTest):
 
         page1 = self.create_pages()[0]
         page_ext = PageMeta.objects.create(extended_object=page1)
-        title_meta = TitleMeta.objects.create(extended_object=page1.get_content_obj("en"))
+        content = PageContent.admin_manager.get(page=page1, language="en")
+        title_meta = TitleMeta.objects.create(extended_object=content)
         default_meta_image = DefaultMetaImage.objects.first()
         request = self.get_page_request(page1, self.staff_user)
         toolbar = CMSToolbar(request)
@@ -173,7 +175,7 @@ class ToolbarTest(BaseTest):
         )
         url_change = False
         url_add = False
-        for title in page1.pagecontent_set.all():
+        for title in PageContent.admin_manager.filter(page=page1):
             language = get_language_object(title.language)
             titlemeta_menu = meta_menu.find_items(ModalItem, name="{}...".format(language["name"]))
             self.assertEqual(len(titlemeta_menu), 1)


### PR DESCRIPTION
Makes it so that meta data is always editable and that it works with non-published draft pages.

It's confusing how cms page metadata actually works. I do not think it is currently versioned and is the same for the whole page and page contents

Uncertain how it should interact with versioning and change should probably be avoid if an official update happens in the original library